### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         run: echo "##[set-output name=VERSION;]$(echo ${GITHUB_REF#refs/tags/})"
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: metaheed/kolle
           workdir: kolle/build/container


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore